### PR TITLE
Fix reorder python imports hook

### DIFF
--- a/project/.pre-commit-config.yaml
+++ b/project/.pre-commit-config.yaml
@@ -30,6 +30,7 @@ repos:
     rev: v3.8.2
     hooks:
     -   id: reorder-python-imports
+        args: ["--application-directories=.:src"]
 
 # Trailing comma
 -   repo: https://github.com/asottile/add-trailing-comma


### PR DESCRIPTION
Now it's completely working with `src` project structure